### PR TITLE
Fix po/Makefile.in.in being overwritten

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,9 +23,6 @@ LT_INIT([disable-static])
 # =========== take care of some localization ========= #
 IT_PROG_INTLTOOL([0.40.0])
 
-AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.18.1])
-
 GETTEXT_PACKAGE=indicator-sensors
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Gettext package])


### PR DESCRIPTION
As stated in the [intltool docs](https://code.launchpad.net/~robert-ancell/intltool/remove-am-gnu-gettext/+merge/114274) `AM_GNU_GETTEXT*` macros should not be used in combination with `IT_PROG_INTLTOOL`. Otherwise autopoint will overwrite po/Makefile.in.in.

After applying this fix, the builds of `ppa:alexmurray/indicator-sensors-daily` for Trusty should work again and the package might be released for Trusty (some people seem to be interested e.g. [here](http://askubuntu.com/questions/450883/sensor-indicator-for-ubuntu-14-04) or [here](http://askubuntu.com/questions/449898/cpu-temperature-monitor-for-14-04lts))
