### PR TITLE
Use po/LINGUAS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,6 @@ AM_GNU_GETTEXT_VERSION([0.18.1])
 GETTEXT_PACKAGE=indicator-sensors
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Gettext package])
-ALL_LINGUAS="ar ca cs de en_GB eo es fr gl he hr hu it ko lt nl pl ro ru sk sr tr uk zh_CN"
 
 # ========== export compiler / linker options ======== #
 AC_SUBST(CFLAGS)

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,0 +1,25 @@
+# please keep this list sorted alphabetically
+ar
+ca
+cs
+de
+en_GB
+eo
+es
+fr
+gl
+he
+hr
+hu
+it
+ko
+lt
+nl
+pl
+ro
+ru
+sk
+sr
+tr
+uk
+zh_CN


### PR DESCRIPTION
In most official Gnome projects the `ALL_LINGUAS` macro in `configure.ac` has been replaced with a file called `po/LINGUAS` (intltool >= 0.35 is required). This way translators just have to care about the files in `po/` and don't have to edit `configure.ac`.

As this is a relatively small project it might not be as useful as in other, bigger projects. However, it might be a good idea to be consistent with other projects.

For further details: [«GNOME Goal: LINGUAS»](https://wiki.gnome.org/Initiatives/GnomeGoals/PoLinguas)
