### PR TITLE
Restore decimal point in temperature sensor

### DIFF
--- a/indicator-sensors/is-temperature-sensor.c
+++ b/indicator-sensors/is-temperature-sensor.c
@@ -148,7 +148,7 @@ is_temperature_sensor_new(const gchar *path)
 {
 	return g_object_new(IS_TYPE_TEMPERATURE_SENSOR,
 			    "path", path,
-                            "digits", 0,
+                            "digits", 1,
 			    "scale", IS_TEMPERATURE_SENSOR_SCALE_CELSIUS,
 			    "high-value", 100.0,
 			    NULL);


### PR DESCRIPTION
Hello,

I just updated indicator-sensors and I discovered that the decimal part of the temperature degrees is not being shown anymore. This is doubly annoying, since the problem happens in both the indicator and the dropdown menu. This patch restores the decimal part as it was before.

Or, should I add this as a configuration option in the preferences dialog?

Thanks,
Vittorio G
