### PR TITLE
Change dynamic and max plugins to monitor only temperature sensors

### DIFF
--- a/plugins/dynamic/is-dynamic-plugin.c
+++ b/plugins/dynamic/is-dynamic-plugin.c
@@ -234,8 +234,8 @@ on_sensor_enabled(IsManager *manager,
 {
   IsDynamicPlugin *self = (IsDynamicPlugin *)data;
 
-  // don't bother monitoring any virtual sensors
-  if (!g_str_has_prefix(is_sensor_get_path(sensor), "virtual/") != 0)
+  // don't bother monitoring non-temperature sensors
+  if (IS_IS_TEMPERATURE_SENSOR(sensor))
   {
     is_debug("dynamic", "sensor enabled: %s", is_sensor_get_label(sensor));
     on_sensor_value_notify(sensor, NULL, self);
@@ -252,8 +252,8 @@ on_sensor_disabled(IsManager *manager,
   IsDynamicPlugin *self = (IsDynamicPlugin *)data;
   IsDynamicPluginPrivate *priv = self->priv;
 
-  // don't bother monitoring any virtual sensors
-  if (!g_str_has_prefix(is_sensor_get_path(sensor), "virtual/") != 0)
+  // don't bother monitoring non-temperature sensors
+  if (IS_IS_TEMPERATURE_SENSOR(sensor))
   {
     is_debug("dynamic", "sensor disabled: %s", is_sensor_get_label(sensor));
     g_signal_handlers_disconnect_by_func(sensor,
@@ -279,7 +279,10 @@ on_sensor_disabled(IsManager *manager,
            _list != NULL;
            _list = _list->next)
       {
-        on_sensor_value_notify(IS_SENSOR(_list->data), NULL, self);
+        if (IS_IS_TEMPERATURE_SENSOR(_list->data))
+        {
+          on_sensor_value_notify(IS_SENSOR(_list->data), NULL, self);
+        }
       }
     }
 

--- a/plugins/max/is-max-plugin.c
+++ b/plugins/max/is-max-plugin.c
@@ -179,8 +179,8 @@ on_sensor_enabled(IsManager *manager,
 {
   IsMaxPlugin *self = (IsMaxPlugin *)data;
 
-  // don't bother monitoring any virtual sensors
-  if (!g_str_has_prefix(is_sensor_get_path(sensor), "virtual/") != 0)
+  // don't bother monitoring non-temperature sensors
+  if (IS_IS_TEMPERATURE_SENSOR(sensor))
   {
     is_debug("max", "sensor enabled: %s", is_sensor_get_label(sensor));
     on_sensor_value_notify(sensor, NULL, self);
@@ -197,8 +197,8 @@ on_sensor_disabled(IsManager *manager,
   IsMaxPlugin *self = (IsMaxPlugin *)data;
   IsMaxPluginPrivate *priv = self->priv;
 
-  // don't bother monitoring any virtual sensors
-  if (!g_str_has_prefix(is_sensor_get_path(sensor), "virtual/") != 0)
+  // don't bother monitoring non-temperature sensors
+  if (IS_IS_TEMPERATURE_SENSOR(sensor))
   {
     is_debug("max", "sensor disabled: %s", is_sensor_get_label(sensor));
     g_signal_handlers_disconnect_by_func(sensor,
@@ -224,9 +224,12 @@ on_sensor_disabled(IsManager *manager,
            _list != NULL;
            _list = _list->next)
       {
-        on_sensor_value_notify(IS_SENSOR(_list->data),
-                               NULL,
-                               self);
+        if (IS_IS_TEMPERATURE_SENSOR(_list->data))
+        {
+          on_sensor_value_notify(IS_SENSOR(_list->data),
+                                 NULL,
+                                 self);
+        }
       }
     }
   }


### PR DESCRIPTION
"Max" and "dynamic" sensor aren't working very well when monitoring sensors with different units (e.g. when you are watching fan and temp sensors at the same time).
I think the best way to fix this is simply to ignore all non-temperature sensors (that includes other virtual).
